### PR TITLE
fix: enforce OpenGL 3.3 Core profile, initialize global VAO, and corr…

### DIFF
--- a/gui/application.py
+++ b/gui/application.py
@@ -32,14 +32,25 @@ class MHApplication(QApplication):
     """
     def __init__(self, glob, argv):
         self.env = glob.env
-        super().__init__(argv)
 
-        # Alphacover (if available), is used to use more than one alpha-layer
+        # QSurfaceFormat must be set BEFORE QApplication is created so that
+        # the OpenGL widget picks up the correct format on all platforms.
+        # On Linux/Mesa the system default is OpenGL 2.0 with no depth buffer,
+        # which causes shaders (#version 330) to fail and the desktop to bleed
+        # through the viewport.  Explicitly request OpenGL 3.3 Core + depth buffer.
         #
         self.sformat = QSurfaceFormat()
+        self.sformat.setVersion(3, 3)
+        self.sformat.setProfile(QSurfaceFormat.OpenGLContextProfile.CoreProfile)
+        self.sformat.setDepthBufferSize(24)
+        self.sformat.setStencilBufferSize(8)
+        self.sformat.setSwapBehavior(QSurfaceFormat.SwapBehavior.DoubleBuffer)
+        # Alphacover (if available), is used to use more than one alpha-layer
         if self.env.noalphacover is False:
             self.sformat.setSamples(4)
-        self.sformat.setDefaultFormat(self.sformat)
+        QSurfaceFormat.setDefaultFormat(self.sformat)
+
+        super().__init__(argv)
 
     def getFormat(self):
         return self.sformat

--- a/opengl/camera.py
+++ b/opengl/camera.py
@@ -303,6 +303,7 @@ class Camera():
         """
         xAngle = (self.last_mousex - x) * self.deltaAngleX
         yAngle = (self.last_mousey - y) * self.deltaAngleY
+        self.setLastMousePosition(x, y)
         self.rotation(xAngle, yAngle)
 
     def mousePanning(self, x, y):

--- a/opengl/main.py
+++ b/opengl/main.py
@@ -9,7 +9,8 @@
 from PySide6.QtOpenGLWidgets import QOpenGLWidget
 from PySide6.QtWidgets import QSizePolicy
 from PySide6.QtCore import QSize, Qt, QTimer
-from PySide6.QtGui import QMatrix4x4, QVector3D
+from PySide6.QtGui import QMatrix4x4, QVector3D, QSurfaceFormat
+from PySide6.QtOpenGL import QOpenGLVertexArrayObject
 
 # try to keep only constants here
 #
@@ -28,6 +29,10 @@ class OpenGLView(QOpenGLWidget):
         self.glob = glob
         self.env = glob.env
         super().__init__()
+        # Explicitly apply the default surface format to this widget so that
+        # Linux/Mesa always gets OpenGL 3.3 Core + depth buffer regardless of
+        # the order in which Qt processes the global default format.
+        self.setFormat(QSurfaceFormat.defaultFormat())
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.MinimumExpanding)
         self.setMinimumSize(QSize(300, 560))
         self.setMaximumSize(QSize(2000, 2000))
@@ -52,6 +57,7 @@ class OpenGLView(QOpenGLWidget):
         self.glfunc = None
         self.marker = None
         self.scene = None
+        self.vao = None
 
     def setFPS(self, value, callback=None):
         self.fps = value
@@ -220,6 +226,15 @@ class OpenGLView(QOpenGLWidget):
         """
         self.glob.openGLBlock = False
         self.glfunc = self.context().functions()
+
+        # OpenGL 3.3 Core Profile requires at least one VAO to be bound before
+        # any vertex attribute pointer calls (glVertexAttribPointer /
+        # glEnableVertexAttribArray).  Create a single VAO and keep it bound
+        # for the lifetime of this widget so all existing BindBuffersToShader
+        # calls work without needing per-object VAOs.
+        self.vao = QOpenGLVertexArrayObject()
+        self.vao.create()
+        self.vao.bind()
 
         deb = GLDebug(self.env.osindex)
         if deb.checkVersion() is False:
@@ -423,3 +438,6 @@ class OpenGLView(QOpenGLWidget):
         if self.skybox is not None:
             self.skybox.delete()
             self.skybox = None
+        if self.vao is not None:
+            self.vao.destroy()
+            self.vao = None


### PR DESCRIPTION
This pull request focuses on improving OpenGL initialization and compatibility across platforms, particularly for Linux/Mesa systems. The main changes ensure that the application consistently requests an OpenGL 3.3 Core Profile context with appropriate depth and stencil buffers, and also address requirements for VAO (Vertex Array Object) usage in Core Profile. There is also a minor bug fix in camera rotation handling.

**OpenGL context and format initialization:**

* In `gui/application.py`, the `QSurfaceFormat` is now explicitly configured for OpenGL 3.3 Core Profile with a depth buffer, stencil buffer, double buffering, and multisampling if available. The format is set before the `QApplication` is created to ensure all widgets use the correct context.
* In `opengl/main.py`, the OpenGL widget (`QOpenGLWidget`) explicitly applies the default surface format on initialization, ensuring the correct context is used regardless of Qt’s internal handling order.
* The necessary imports for `QSurfaceFormat` and `QOpenGLVertexArrayObject` are added to `opengl/main.py`.

**OpenGL Core Profile VAO requirement:**

* In `opengl/main.py`, a single `QOpenGLVertexArrayObject` (VAO) is created, bound during initialization, and destroyed during cleanup. This ensures compliance with OpenGL 3.3 Core Profile, which requires a VAO to be bound before making vertex attribute calls. [[1]](diffhunk://#diff-dcedb17612574e81e38a03f30816dd4312251975fd8aa32c54daa500c7da81d5R60) [[2]](diffhunk://#diff-dcedb17612574e81e38a03f30816dd4312251975fd8aa32c54daa500c7da81d5R230-R238) [[3]](diffhunk://#diff-dcedb17612574e81e38a03f30816dd4312251975fd8aa32c54daa500c7da81d5R441-R443)

**Bug fix:**

* In `opengl/camera.py`, the last mouse position is updated in `arcBallRotation`, fixing potential issues with rotation state.